### PR TITLE
Add support Qwen2.5-Math-Instruct

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -10,10 +10,28 @@ pip install transformers==4.42.3
 ```
 
 ### Evaluation
-You can evaluate Qwen2-Math-Instruct series model with the following command:
+You can evaluate Qwen2.5/Qwen2-Math-Instruct series model with the following command:
 ```bash
-PROMPT_TYPE="qwen-boxed"
+# Qwen2.5-Math-Instruct Series
+PROMPT_TYPE="qwen25-math-cot"
+# Qwen2.5-Math-1.5B-Instruct
+export CUDA_VISIBLE_DEVICES="0"
+MODEL_NAME_OR_PATH="Qwen/Qwen2.5-Math-1.5B-Instruct"
+bash sh/eval.sh $PROMPT_TYPE $MODEL_NAME_OR_PATH
 
+# Qwen2.5-Math-7B-Instruct
+export CUDA_VISIBLE_DEVICES="0"
+MODEL_NAME_OR_PATH="Qwen/Qwen2.5-Math-7B-Instruct"
+bash sh/eval.sh $PROMPT_TYPE $MODEL_NAME_OR_PATH
+
+# Qwen2.5-Math-72B-Instruct
+export CUDA_VISIBLE_DEVICES="0,1,2,3"
+MODEL_NAME_OR_PATH="Qwen/Qwen2.5-Math-72B-Instruct"
+bash sh/eval.sh $PROMPT_TYPE $MODEL_NAME_OR_PATH
+
+
+# Qwen2-Math-Instruct Series
+PROMPT_TYPE="qwen-boxed"
 # Qwen2-Math-1.5B-Instruct
 export CUDA_VISIBLE_DEVICES="0"
 MODEL_NAME_OR_PATH="Qwen/Qwen2-Math-1.5B-Instruct"

--- a/evaluation/parser.py
+++ b/evaluation/parser.py
@@ -531,9 +531,9 @@ def extract_answer(pred_str, data_name, use_last_number=True):
         pred = pred_str.split("he answer is")[-1].strip()
     elif "final answer is" in pred_str:
         pred = pred_str.split("final answer is")[-1].strip()
-    # elif extract_program_output(pred_str) != "":
-    # fall back to program
-    # pred = extract_program_output(pred_str)
+    elif "答案是" in pred_str:
+        # Handle Chinese few-shot multiple choice problem answer extraction
+        pred = pred_str.split("答案是")[1].strip().split("\n\n")[0].strip()
     else:  # use the last number
         if use_last_number:
             pattern = "-?\d*\.?\d+"

--- a/evaluation/sh/run_eval_qwen2_math.sh
+++ b/evaluation/sh/run_eval_qwen2_math.sh
@@ -1,3 +1,23 @@
+# Evaluate Qwen2.5-Math-Instruct
+PROMPT_TYPE="qwen25-math-cot"
+
+# Qwen2.5-Math-1.5B-Instruct
+export CUDA_VISIBLE_DEVICES="0"
+MODEL_NAME_OR_PATH="Qwen/Qwen2.5-Math-1.5B-Instruct"
+bash sh/eval.sh $PROMPT_TYPE $MODEL_NAME_OR_PATH
+
+# Qwen2.5-Math-7B-Instruct
+export CUDA_VISIBLE_DEVICES="0"
+MODEL_NAME_OR_PATH="Qwen/Qwen2.5-Math-7B-Instruct"
+bash sh/eval.sh $PROMPT_TYPE $MODEL_NAME_OR_PATH
+
+# Qwen2.5-Math-72B-Instruct
+export CUDA_VISIBLE_DEVICES="0,1,2,3"
+MODEL_NAME_OR_PATH="Qwen/Qwen2.5-Math-72B-Instruct"
+bash sh/eval.sh $PROMPT_TYPE $MODEL_NAME_OR_PATH
+
+
+# Evaluate Qwen2-Math-Instruct
 PROMPT_TYPE="qwen-boxed"
 
 # Qwen2-Math-1.5B-Instruct


### PR DESCRIPTION
1. Add prompt template for Qwen2.5-Math-Instruct for CoT reasoning.
2. Add support for evaluating Qwen2.5-Math-Instruct in the few-shot setting and Chinese benchmarks.